### PR TITLE
Fix missing French strings in Freehand Drawing plugin

### DIFF
--- a/src/localization.ts
+++ b/src/localization.ts
@@ -158,6 +158,58 @@ const localizations: Record<string, Partial<AppLocalization>> = {
 			`Die Ressource ${resourceId} ist kein bearbeitbares Bild. Ressource vom Typ ${resourceType} kann nicht bearbeitet werden.`,
 	},
 	en: defaultStrings,
+	fr: {
+		insertDrawing: 'Insérer un dessin',
+		insertDrawingInNewWindow: 'Insérer un dessin dans une nouvelle fenêtre',
+		restoreFromAutosave: 'Restaurer depuis la sauvegarde automatique',
+		deleteAutosave: 'Supprimer toutes les sauvegardes automatiques',
+		noSuchAutosaveExists: 'Aucune sauvegarde automatique n’existe',
+		discardChanges: 'Ignorer les modifications',
+		defaultImageTitle: 'Dessin à main levée',
+	  
+		edit: 'Modifier',
+		close: 'Fermer',
+		saveAndClose: 'Enregistrer et fermer',
+	  
+		overwriteExisting: 'Écraser l’existant',
+		saveAsNewDrawing: 'Enregistrer comme nouveau dessin',
+		clickBelowToContinue: 'Terminé ! Cliquez ci-dessous pour continuer.',
+		discardUnsavedChanges: 'Ignorer les modifications non enregistrées ?',
+		resumeEditing: 'Reprendre l’édition',
+		saveAndResumeEditing: 'Enregistrer et continuer l’édition',
+		saveChanges: 'Enregistrer les modifications',
+		exitInstructions: 'Toutes les modifications sont enregistrées. Cliquez ci-dessous pour quitter.',
+	  
+		settingsPaneDescription: 'Paramètres pour l’éditeur de dessin.',
+		setting__disableFullScreen: 'Mode dialogue',
+		setting__disableFullScreenDescription:
+		  'Lorsque cette option est activée, l’éditeur ne remplit que partiellement la fenêtre Joplin.',
+		setting__autosaveIntervalSettingLabel: 'Intervalle de sauvegarde automatique (minutes)',
+		setting__autosaveIntervalSettingDescription:
+		  'Définit la fréquence de création des sauvegardes automatiques du dessin courant.',
+		setting__themeLabel: 'Thème',
+		setting__toolbarTypeLabel: 'Type de barre d’outils',
+		setting__toolbarTypeDescription:
+		  'Cette option permet de changer l’interface de la barre d’outils de l’éditeur.',
+		setting__keyboardShortcuts: 'Raccourcis clavier',
+	  
+		toolbarTypeDefault: 'Par défaut',
+		toolbarTypeSidebar: 'Barre latérale',
+		toolbarTypeDropdown: 'Menu déroulant',
+	  
+		styleMatchJoplin: 'Identique à Joplin',
+		styleJsDrawLight: 'Clair',
+		styleJsDrawDark: 'Sombre',
+	  
+		images: 'Images',
+		pdfs: 'PDF',
+		allFiles: 'Tous les fichiers',
+	  
+		loadLargePdf: (pageCount: number) =>
+		  `Le fichier sélectionné est un PDF volumineux (${pageCount} pages). Son chargement peut prendre du temps et augmenter la taille du dessin. Continuer ?`,
+		notAnEditableImage: (resourceId: string, resourceType: string) =>
+		  `La ressource ${resourceId} n’est pas une image modifiable. Impossible de modifier une ressource de type ${resourceType}.`,
+	  },	  
 	es: {
 		insertDrawing: 'Añada dibujo',
 		restoreFromAutosave: 'Resturar al autoguardado',


### PR DESCRIPTION
This PR adds missing French (fr) strings to the Freehand Drawing plugin UI.
These labels were not present in the localization map before, so they did not appear in translation files and were falling back to English.
This fixes the missing translation issue reported in joplin#14097.